### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+
+services:
+  - docker
+
+env:
+  - DOCKER_COMPOSE_VERSION=1.23.2
+
+before_install:
+    - sudo rm /usr/local/bin/docker-compose
+    - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+    - chmod +x docker-compose
+    - sudo mv docker-compose /usr/local/bin
+    - docker-compose build
+
+script:
+    - docker-compose up -d --build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# symptomsurvey_backend
+# symptomsurvey_backend ![travisci badge](https://travis-ci.org/CodeForPortland/symptomsurvey_backend.svg?branch=master)
 
 This repository is the API for a website for use by Clackamas County.  These are developer notes.
 

--- a/blah.txt
+++ b/blah.txt
@@ -1,0 +1,1 @@
+just makin a commit so travis will update

--- a/blah.txt
+++ b/blah.txt
@@ -1,1 +1,0 @@
-just makin a commit so travis will update

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       dockerfile: ./WEB/Dockerfile
     ports:
       #restricts to localhost, remove the ip prefix to allow public access
-      - 127.0.0.1:5000:5000
+      - 5000:5000
     depends_on:
       - mongo
       - manage


### PR DESCRIPTION
First thing this pr does which is unrelated to travis is remove the restriction to localhost on line 12 of `docker-compose.yml`. You can see that change [here](https://github.com/CodeForPortland/symptomsurvey_backend/compare/travis?expand=1#diff-4e5e90c6228fd48698d074241c2ba760L12). With this restriction, you cannot access the server from a browser when using docker toolbox. If I should make a separate PR for this issue let me know, but the past few weeks some new folks have had to use docker toolbox and make this change manually.

Next, I added the travis yaml which is based off some code from [here](https://docs.travis-ci.com/user/docker/#using-docker-compose). At this moment, since we have not set up any tests it just runs the server. Whenever @GerryFudd finishes setting up the test framework, I'll edit the travis yaml to support them.

You can view the status of the build at https://travis-ci.org/CodeForPortland/symptomsurvey_backend

