### PR TITLE
Tweet search endpoint

### DIFF
--- a/WEB/controllers/tweets.py
+++ b/WEB/controllers/tweets.py
@@ -29,9 +29,16 @@ def add_routes(app):
     except Exception as ex:
       return json.dumps({'Exception': str(ex)}), 500, JSON_CONTENT_TYPE
 
-  @app.route('/tweets', methods=['POST'])
-  def getTweets():
+  @app.route('/tweets/realtime', methods=['POST'])
+  def getLiveTweets():
     body = request.get_json()
     search_text = body.get('search', '')
     tweets = tweets_service.get_tweets_from_twitter(search_text, body.get('geolocation'))
     return json.dumps(tweets), 200, JSON_CONTENT_TYPE
+
+  @app.route('/tweets', methods=['POST'])
+  def getTweets():
+    body = request.get_json()
+    search_text = body.get('search')
+    tweets = tweets_service.get_tweets_from_db(search_text)
+    return tweets, 200, JSON_CONTENT_TYPE

--- a/WEB/controllers/tweets.py
+++ b/WEB/controllers/tweets.py
@@ -1,6 +1,9 @@
 import json
 
 from services import auth_service, tweets_service
+from flask import request
+
+JSON_CONTENT_TYPE = {'Content-Type': 'application/json'}
 
 def add_routes(app):
   @app.route('/tweets/load', endpoint='load_tweets')
@@ -22,6 +25,13 @@ def add_routes(app):
     tweets = tweets_service.get_tweets_from_twitter()
     try:
       tweets_service.save_tweets(tweets["statuses"])
-      return json.dumps(tweets), 200, {'Content-Type': 'application/json'}
+      return json.dumps(tweets), 200, JSON_CONTENT_TYPE
     except Exception as ex:
-      return json.dumps({'Exception': str(ex)}), 500, {'Content-Type': 'application/json'}
+      return json.dumps({'Exception': str(ex)}), 500, JSON_CONTENT_TYPE
+
+  @app.route('/tweets', methods=['POST'])
+  def getTweets():
+    body = request.get_json()
+    search_text = body.get('search', '')
+    tweets = tweets_service.get_tweets_from_twitter(search_text)
+    return json.dumps(tweets), 200, JSON_CONTENT_TYPE

--- a/WEB/controllers/tweets.py
+++ b/WEB/controllers/tweets.py
@@ -33,5 +33,5 @@ def add_routes(app):
   def getTweets():
     body = request.get_json()
     search_text = body.get('search', '')
-    tweets = tweets_service.get_tweets_from_twitter(search_text)
+    tweets = tweets_service.get_tweets_from_twitter(search_text, body.get('geolocation'))
     return json.dumps(tweets), 200, JSON_CONTENT_TYPE

--- a/WEB/services/database_service.py
+++ b/WEB/services/database_service.py
@@ -28,9 +28,13 @@ class MongoSession:
     # TODO: add a password to the mongo database so that its contents are hidden behind this API
     app.config['MONGO_URI'] = 'mongodb://{0}:{1}/{2}'.format(mongo_host, mongo_port, database_name)
     MongoSession.instance.mongo = flask_pymongo.PyMongo(app)
+    self.create_indexes()
 
   def get_mongo_client(self):
     return MongoSession.instance.mongo
+
+  def create_indexes(self):
+    MongoSession.instance.mongo.db.tweets.create_index([('text', 'text')])
 
 def get_mongo_client():
   return MongoSession().get_mongo_client()

--- a/WEB/services/tweets_service.py
+++ b/WEB/services/tweets_service.py
@@ -34,7 +34,7 @@ def format_geolocation(geolocation):
     latitude,longitude,radius = [geolocation.get(k) for k in ('latitude', 'longitude', 'radius')]
     if latitude is not None and longitude is not None and radius is not None:
       parsed_radius = radius if 'mi' in radius or 'km' in radius else radius + 'mi'
-      return f'${latitude},${longitude},${parsed_radius}'
+      return f'{latitude},{longitude},{parsed_radius}'
     
     # If you wound up here then we don't have any valid input, just return empty string
     return ''

--- a/WEB/services/tweets_service.py
+++ b/WEB/services/tweets_service.py
@@ -8,9 +8,9 @@ data = {
   'grant_type': 'client_credentials'
 }
 
-def get_tweets_from_twitter():
+def get_tweets_from_twitter(search_text = ''):
   auth_response = requests.post('https://api.twitter.com/oauth2/token', data=data, auth=(os.environ['TWITTER_API_KEY'], os.environ['TWITTER_API_ACCESS_KEY']))
-  tweet_search_params = {'q': '', 'geocode': '45.209358,-122.246009,30mi', 'count': 100}
+  tweet_search_params = {'q': format_search_text(search_text), 'geocode': '45.209358,-122.246009,30mi', 'count': 100}
   tweet_headers = {'Authorization': 'Bearer {}'.format(auth_response.json()['access_token'])}
   print(tweet_headers)
   print(tweet_search_params)
@@ -21,3 +21,6 @@ def save_tweets(tweets):
   mongo = database_service.get_mongo_client()
 
   mongo.db.tweets.insert_many(copy.deepcopy(tweets))
+
+def format_search_text(search_text = ''):
+  return search_text.replace(' && ', ' ').replace(' || ',  ' OR ')

--- a/WEB/services/tweets_service.py
+++ b/WEB/services/tweets_service.py
@@ -15,7 +15,7 @@ CLACKAMAS_GEO = {
 
 def get_tweets_from_twitter(search_text = '', geolocation = CLACKAMAS_GEO):
   auth_response = requests.post('https://api.twitter.com/oauth2/token', data=DATA, auth=(os.environ['TWITTER_API_KEY'], os.environ['TWITTER_API_ACCESS_KEY']))
-  tweet_search_params = {'q': format_search_text(search_text), 'geocode': format_geolocation(geolocation if geolocation is not None else CLACKAMAS_GEO), 'count': 100}
+  tweet_search_params = {'q': format_search_text(search_text), 'geocode': format_geolocation(geolocation), 'count': 100}
   tweet_headers = {'Authorization': 'Bearer {}'.format(auth_response.json()['access_token'])}
   print(tweet_headers)
   print(tweet_search_params)
@@ -30,9 +30,11 @@ def format_search_text(search_text = ''):
   return search_text.replace(' && ', ' ').replace(' || ',  ' OR ')
 
 def format_geolocation(geolocation):
-  latitude,longitude,radius = [geolocation.get(k) for k in ('latitude', 'longitude', 'radius')]
-  if latitude is not None and longitude is not None and radius is not None:
-    parsed_radius = radius if 'mi' in radius or 'km' in radius else radius + 'mi'
-    return f'${latitude},${longitude},${parsed_radius}'
-  else:
+  if geolocation is not None:
+    latitude,longitude,radius = [geolocation.get(k) for k in ('latitude', 'longitude', 'radius')]
+    if latitude is not None and longitude is not None and radius is not None:
+      parsed_radius = radius if 'mi' in radius or 'km' in radius else radius + 'mi'
+      return f'${latitude},${longitude},${parsed_radius}'
+    
+    # If you wound up here then we don't have any valid input, just return empty string
     return ''

--- a/WEB/services/tweets_service.py
+++ b/WEB/services/tweets_service.py
@@ -4,13 +4,18 @@ import copy
 
 from services import database_service
 
-data = {
+DATA = {
   'grant_type': 'client_credentials'
 }
+CLACKAMAS_GEO = {
+  'latitude': '45.209358',
+  'longitude': '-122.246009',
+  'radius': '30mi'
+}
 
-def get_tweets_from_twitter(search_text = ''):
-  auth_response = requests.post('https://api.twitter.com/oauth2/token', data=data, auth=(os.environ['TWITTER_API_KEY'], os.environ['TWITTER_API_ACCESS_KEY']))
-  tweet_search_params = {'q': format_search_text(search_text), 'geocode': '45.209358,-122.246009,30mi', 'count': 100}
+def get_tweets_from_twitter(search_text = '', geolocation = CLACKAMAS_GEO):
+  auth_response = requests.post('https://api.twitter.com/oauth2/token', data=DATA, auth=(os.environ['TWITTER_API_KEY'], os.environ['TWITTER_API_ACCESS_KEY']))
+  tweet_search_params = {'q': format_search_text(search_text), 'geocode': format_geolocation(geolocation if geolocation is not None else CLACKAMAS_GEO), 'count': 100}
   tweet_headers = {'Authorization': 'Bearer {}'.format(auth_response.json()['access_token'])}
   print(tweet_headers)
   print(tweet_search_params)
@@ -19,8 +24,15 @@ def get_tweets_from_twitter(search_text = ''):
 
 def save_tweets(tweets):
   mongo = database_service.get_mongo_client()
-
   mongo.db.tweets.insert_many(copy.deepcopy(tweets))
 
 def format_search_text(search_text = ''):
   return search_text.replace(' && ', ' ').replace(' || ',  ' OR ')
+
+def format_geolocation(geolocation):
+  latitude,longitude,radius = [geolocation.get(k) for k in ('latitude', 'longitude', 'radius')]
+  if latitude is not None and longitude is not None and radius is not None:
+    parsed_radius = radius if 'mi' in radius or 'km' in radius else radius + 'mi'
+    return f'${latitude},${longitude},${parsed_radius}'
+  else:
+    return ''


### PR DESCRIPTION
Adds a POST endpoint at /tweets to search straight to twitter. A little bit more flexible than we initially intended so we'll need an additional endpoint for the DB based search.

This PR still needs some swagger documentation and a unit test or two.