### PR TITLE
container structure reorg

### DIFF
--- a/WEB/Dockerfile
+++ b/WEB/Dockerfile
@@ -1,11 +1,23 @@
 FROM python:3.6-slim
 
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="symptomsurvey_backed/WEB"
+LABEL org.label-schema.description="Social Media Scraper for public health issues in Clakamas County Oregon"
+LABEL org.label-schema.url="http://www.codeforpdx.org/projects/2"
+LABEL org.label-schema.vcs-url="https://github.com/codeforpdx/symptomsurvey_backend"
+
 WORKDIR /usr/src/app
 
+# TODO: Add EXPOSE instruction to specify port that will be exposed
+
 #do this BEFORE copying the rest, that way only changes to requirements.txt will cause pip to execute
-COPY ./WEB/requirements.txt ./requirements.txt
-RUN pip3 install -r requirements.txt
+COPY ./WEB/requirements.txt ./WEB/requirements.txt
+RUN pip install --upgrade pip
+RUN pip3 install -r ./WEB/requirements.txt
 
-COPY ./WEB ./SHARED ./
+COPY ./WEB/. ./WEB
+COPY ./SHARED/. ./SHARED
 
-CMD ["flask", "run", "--host=0.0.0.0"]
+WORKDIR /usr/src/app/WEB
+# Start Website back-end
+CMD ["flask", "run", "--host=0.0.0.0", "--port=5000"]

--- a/WEB/app.py
+++ b/WEB/app.py
@@ -8,10 +8,8 @@ from services import database_service
 from services import auth_service
 
 
-
-# configure flask app
-def create_app(testconfig = None):
-
+def create_app(testconfig=None):
+  """Configure Flask app."""
   appInfo = {
               "swagger": "2.0",
               "info": {
@@ -32,28 +30,31 @@ def create_app(testconfig = None):
               ]
             }
 
- 
   app = flask.Flask(__name__)
   flask_cors.CORS(app)
   Swagger(app, template=appInfo)
   # Create a mongo client that works with the flask configuration.
   if testconfig is None:
-    # Load the values from the constants file.  This file contains the parameters that are used for the
-    # hashing algorithim that is applied to the salted passwords.
-    with open('constants.json') as f:
+    # Load the values from the constants file.  This file contains the
+    # parameters that are used for the hashing algorithim that is
+    # applied to the salted passwords.
+    with open('../SHARED/constants.json') as f:
       constants = json.load(f)
 
-    # Read the private key from `./keys/token`. This file is gitignored so that our private key is not
-    # checked into version control.
+    # Read the private key from `./keys/token`. This file is gitignored so
+    # that our private key is not checked into version control.
     with open('keys/token') as key:
       private_key = key.read()
 
-    # Read the private key from `./keys/token`. This file is gitignored so that our private key is not
-    # checked into version control.
+    # Read the private key from `./keys/token`. This file is gitignored so
+    # that our private key is not checked into version control.
     with open('keys/token.pub') as key:
       public_key = key.read()
-      
-    database_service.MongoSession().configure_instance(app, constants['database_name'])
+
+    database_service.MongoSession().configure_instance(
+        app,
+        constants['database_name']
+    )
     auth_service.AuthSession(constants['salt'], private_key, public_key)
   else:
     testconfig.start_test_session()
@@ -61,6 +62,7 @@ def create_app(testconfig = None):
   router.add_routes(app)
   return app
 
+
 if __name__ == '__main__':
   app = create_app()
-  app.run(host="0.0.0.0")
+  app.run()

--- a/WEB/constants.json
+++ b/WEB/constants.json
@@ -1,8 +1,0 @@
-{
-  "salt": {
-    "iterations": 100000,
-    "key_length": 256,
-    "algorithm": "sha256"
-  },
-  "database_name": "social_media_scraper"
-}

--- a/WEB/requirements.txt
+++ b/WEB/requirements.txt
@@ -5,3 +5,4 @@ cryptography == 2.4.2
 pytest == 4.2.1
 requests == 2.21.0
 flasgger == 0.9.2
+ipython == 7.2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 #docker-compose version
 version: '2.4'
 
-
 services:
   web: #defines the main flask application enclosure
+    container_name: sms-flask
     build:
       context: ./
       dockerfile: ./WEB/Dockerfile
@@ -19,10 +19,9 @@ services:
       #Should only be used for debugging.
       FLASK_DEBUG: 1
       #End of debugging config
-      FLASK_APP: app.py
       TWITTER_API_KEY: ${TWITTER_API_KEY}
       TWITTER_API_ACCESS_KEY: ${TWITTER_API_ACCESS_KEY}
-      
+
     #Mounts the app image to the source, to allow dynamic updates of the flask app.
     #Should only be used for debugging.
     #volumes:
@@ -31,7 +30,8 @@ services:
 
 
   manage: #defines a node enclosure for interacting with the mongo database
-    build: 
+    container_name: sms-mongodb-manager
+    build:
       context: ./
       dockerfile: ./MANAGE/Dockerfile
     depends_on:
@@ -53,13 +53,14 @@ services:
 
   mongo: #defines the mongoDB enclosure
     image: mongo:4.0.5
+    container_name: sms-mongodb
     restart: always
     volumes:
       #allows the database to persist when shutdown / across builds
       - symptomsurvey_db_volume:/data/db
       #- type: volume
       #  target: /data/db
-      #  source: symptomsurvey_db_volume   
+      #  source: symptomsurvey_db_volume
 
 volumes:
   symptomsurvey_db_volume:


### PR DESCRIPTION
The file layout between git and the containers were different.  I'd like them to be the same.  This supports running outside of the container if you so chose.  Within the container, files are installed in WEB and SHARED subdirectories the same as they are in git.

Adjusted docker-compose in hopefully good ways.  Added some labels and named the containers to help me remember which is which.